### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Open in Socket.dev
 
-<a href="https://marketplace.visualstudio.com/items?itemName=antfu.ext-name" target="__blank"><img src="https://img.shields.io/visual-studio-marketplace/v/antfu.ext-name.svg?color=eee&amp;label=VS%20Code%20Marketplace&logo=visual-studio-code" alt="Visual Studio Marketplace Version" /></a>
+<a href="https://marketplace.visualstudio.com/items?itemName=JuliusMarminge.open-in-socket-dev" target="__blank"><img src="https://img.shields.io/visual-studio-marketplace/v/JuliusMarminge.open-in-socket-dev.svg?color=eee&amp;label=VS%20Code%20Marketplace&logo=visual-studio-code" alt="Visual Studio Marketplace Version" /></a>
 
 Provides an "Open in Socket.dev" tooltip when hovering package names:
 


### PR DESCRIPTION
This pull request updates the `README.md` file to reflect a change in the Visual Studio Marketplace extension ownership.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3): Updated the Visual Studio Marketplace badge link and identifier to point to the new owner, `JuliusMarminge.open-in-socket-dev`, instead of the previous `antfu.ext-name`.